### PR TITLE
Ignore pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The problem with a lot of webapps is that you can't scroll the content up by sim
 
 ## Demo
 
-Plugin comes with demo example to see how it works and looks. 
+Plugin comes with demo example to see how it works and looks.
 * To check the demo directly from the repository, you should install bower dependencies.  
-Go to `demo/` folder and execute in terminal `bower install` 
+Go to `demo/` folder and execute in terminal `bower install`
 
 * Or you could simply check it here http://www.timo-ernst.net/misc/upscrollerdemo/
 
@@ -29,12 +29,25 @@ Very simple. Just copy the CSS and JS files from `dist/` folder to your project 
 <script type="text/javascript" src="upscroller.min.js"></script>
 ```
 
-The plugin will be initialized automatically. The default label of the button is 'Go up'. 
+The plugin will be initialized automatically. The default label of the button is 'Go up'.
 If you'd like to change the button label, simply declare it during your app's initialization.
 
 ```javascript
 fw7App = new Framework7({
   upscroller: {text : 'Your button label'}
+});
+```
+
+## Ignore pages
+
+The Upscroller Plugin is included in every page you enter. If you want to ignore the upscroller plugin in some pages, you may now user the following parameter:
+
+```javascript
+fw7App = new Framework7({
+  upscroller: {
+    text : 'Your button label',
+    ignorePages: ['about'] // defaults to []
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ fw7App = new Framework7({
 
 ## Ignore pages
 
-The Upscroller Plugin is included in every page you enter. If you want to ignore the upscroller plugin in some pages, you may now user the following parameter:
+The Upscroller Plugin is included in every page you enter. If you want to ignore the upscroller plugin in some pages, you may now use the following parameter:
 
 ```javascript
 fw7App = new Framework7({

--- a/src/framework7.upscroller.js
+++ b/src/framework7.upscroller.js
@@ -1,30 +1,33 @@
 Framework7.prototype.plugins.upscroller = function (app, params) {
     'use strict';
-    params = params || {text: 'Go up'};
+    params = params || {text: 'Go up', ignorePages: []};
     //Export selectors engine
     var $$ = window.Dom7;
 
     return {
         hooks : {
-			pageBeforeInit: function (pageData) {				
-				var $$btn = $$('<div class="upscroller">↑ ' + params.text + '</div>');				
+			pageBeforeInit: function (pageData) {
+        // Ignores upscroller plugin if page is ignored
+        if (params.ignorePages.includes(pageData.name)) return;
+
+				var $$btn = $$('<div class="upscroller">↑ ' + params.text + '</div>');
 				$$(pageData.container).prepend($$btn);
-				
+
 				$$btn.click(function(event) {
 					event.stopPropagation();
 				    event.preventDefault();
-				    var curpage = $$(".page-content", mainView.activePage.container);				
+				    var curpage = $$(".page-content", mainView.activePage.container);
 				    $$(curpage).scrollTop(0, Math.round($$(curpage).scrollTop()/4));
 				});
-				
-				$$(".page-content", pageData.container).scroll(function(event){					  
+
+				$$(".page-content", pageData.container).scroll(function(event){
 				  var e = $$(event.target).scrollTop();
 				  if(e > 300) {
-			          $$btn.addClass('show'); 
+			          $$btn.addClass('show');
 				  }
 				  else {
 			          $$btn.removeClass('show');
-				  }					  
+				  }
 				});
             }
         }


### PR DESCRIPTION
This pull request tries to give the possibility to ignore the plugin in some predetermined pages.

Basically I may want to have the plugin applied in all pages, apart from the main page of my app ;)

Future Work:
May be great to do the same but in the other direction: select the pages we want to apply the plugin.
I decided to do the "ignore" because I'm assuming that someone how uses the plugin wants to use it almost everywhere ;)