### PR TITLE
Added f7. in front of mainview which fixes an undefined mainview in vue

### DIFF
--- a/src/framework7.upscroller.js
+++ b/src/framework7.upscroller.js
@@ -16,7 +16,7 @@ Framework7.prototype.plugins.upscroller = function (app, params) {
 				$$btn.click(function(event) {
 					event.stopPropagation();
 				    event.preventDefault();
-				    var curpage = $$(".page-content", mainView.activePage.container);
+				    var curpage = $$(".page-content", f7.mainView.activePage.container);
 				    $$(curpage).scrollTop(0, Math.round($$(curpage).scrollTop()/4));
 				});
 


### PR DESCRIPTION
I am using the vuejs version of Framework 7 and this fixes a real issue for me that mainView is undefined.
Not sure if this code would be valid in non vuejs environments.